### PR TITLE
Example of getting all certificates urls

### DIFF
--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -1,0 +1,37 @@
+# Run with Python 3
+import json
+import requests
+
+# 1. Get your keys at https://stepic.org/oauth2/applications/ (client type = confidential,
+# authorization grant type = client credentials)
+client_id = "..."
+client_secret = "..."
+
+# 2. Get a token
+auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
+resp = requests.post('https://stepic.org/oauth2/token/',
+                     data={'grant_type': 'client_credentials'},
+                     auth=auth
+                     )
+token = json.loads(resp.text)['access_token']
+
+# 3. Call API (https://stepic.org/api/docs/) using this token.
+# Example:
+
+def get_certificates(page_number):
+    api_url = 'https://stepic.org/api/certificates?page={}'.format(page_number)
+    certificate = json.loads(requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).text)
+
+    for i in certificate['certificates']:
+        print(i['url'])
+
+        file = requests.get(i['url'])
+
+    return certificate['meta']['has_next']
+
+has_next = True
+page = 1
+
+while(has_next):
+    has_next = get_certificates(page)
+    page += 1

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -25,8 +25,6 @@ def get_certificates(page_number):
     for i in certificate['certificates']:
         print(i['url'])
 
-        file = requests.get(i['url'])
-
     return certificate['meta']['has_next']
 
 has_next = True

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -27,12 +27,12 @@ def get_user_id():
 def get_certificates(page_number):
     user_id = get_user_id()
     api_url = 'https://stepic.org/api/certificates?user={}&page={}'.format(user_id, page_number)
-    certificate = requests.get(api_url, headers={'Authorization': 'Bearer ' + token}).json()
+    page = requests.get(api_url, headers={'Authorization': 'Bearer ' + token}).json()
 
-    for i in certificate['certificates']:
-        links.append(i['url'])
+    for certificate in page['certificates']:
+        links.append(certificate['url'])
 
-    return certificate['meta']['has_next']
+    return page['meta']['has_next']
 
 
 def get_certificate_links():

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -47,27 +47,19 @@ def get_certificate_links():
 links = []
 get_certificate_links()
 
-f = open('certificates.html', 'w', encoding='utf-8')
+with open('certificates.html', 'w', encoding='utf-8') as f:
+    f.write('<html> \n')
+    f.write('<head> \n')
+    f.write('<title> Certificates </title> \n')
+    f.write('<style> ol { line-height: 1.5; } </style> \n')
+    f.write('</head> \n')
+    f.write('<body> \n')
+    f.write('<h1> Certificates </h1> \n')
+    f.write('<ol> \n')
 
-begin = """<html>
-<head><title> Certificates </title>
-<style>
-   ol {
-    line-height: 1.5;
-   }
-</style>
-</head>
-<body>
-<h1> Certificates </h1>
-<ol>
-"""
+    for url in links:
+        f.write('<li><a href="{}">{}</a></li> \n'.format(url, url))
 
-end = """</ol>
-</body>
-</html>"""
-
-f.write(begin)
-for url in links:
-    f.write('<li><a href="{}">{}</a></li> \n'.format(url, url))
-f.write(end)
-f.close()
+    f.write('</ol> \n')
+    f.write('</body> \n')
+    f.write('</html> \n')

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -17,16 +17,17 @@ token = resp.json()['access_token']
 # 3. Call API (https://stepic.org/api/docs/) using this token.
 # Example:
 
+
 def get_user_id():
     api_url = 'https://stepic.org/api/stepics/1'
-    user = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
+    user = requests.get(api_url, headers={'Authorization': 'Bearer ' + token}).json()
     return user['users'][0]['id']
 
 
 def get_certificates(page_number):
-    id = get_user_id()
-    api_url = 'https://stepic.org/api/certificates?user={}&page={}'.format(id, page_number)
-    certificate = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
+    user_id = get_user_id()
+    api_url = 'https://stepic.org/api/certificates?user={}&page={}'.format(user_id, page_number)
+    certificate = requests.get(api_url, headers={'Authorization': 'Bearer ' + token}).json()
 
     for i in certificate['certificates']:
         links.append(i['url'])
@@ -38,14 +39,13 @@ def get_certificate_links():
     has_next = True
     page = 1
 
-    while(has_next):
+    while has_next:
         has_next = get_certificates(page)
         page += 1
 
 
 links = []
 get_certificate_links()
-
 
 f = open('certificates.html', 'w', encoding='utf-8')
 
@@ -68,6 +68,6 @@ end = """</ol>
 
 f.write(begin)
 for url in links:
-    f.write('<li><a href="{}">{}</a></li> \n'.format(url ,url))
+    f.write('<li><a href="{}">{}</a></li> \n'.format(url, url))
 f.write(end)
 f.close()

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -1,5 +1,4 @@
 # Run with Python 3
-import json
 import requests
 
 # 1. Get your keys at https://stepic.org/oauth2/applications/ (client type = confidential,
@@ -13,14 +12,14 @@ resp = requests.post('https://stepic.org/oauth2/token/',
                      data={'grant_type': 'client_credentials'},
                      auth=auth
                      )
-token = json.loads(resp.text)['access_token']
+token = resp.json()['access_token']
 
 # 3. Call API (https://stepic.org/api/docs/) using this token.
 # Example:
 
 def get_certificates(page_number):
     api_url = 'https://stepic.org/api/certificates?page={}'.format(page_number)
-    certificate = json.loads(requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).text)
+    certificate = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
 
     for i in certificate['certificates']:
         print(i['url'])

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -26,9 +26,40 @@ def get_certificates(page_number):
 
     return certificate['meta']['has_next']
 
-has_next = True
-page = 1
+# works slow, because data in api/certificates sparsed through pages
+def get_certificate_links():
+    has_next = True
+    page = 1
 
-while(has_next):
-    has_next = get_certificates(page)
-    page += 1
+    while(has_next):
+        has_next = get_certificates(page)
+        page += 1
+
+
+# courses api provides courses without blank pages
+def get_certificates_by_course(links, page_number):
+    api_url = 'https://stepic.org/api/courses?page={}'.format(page_number)
+    courses = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
+
+    for i in courses['courses']:
+        link = i['certificate_link']
+        if link:
+            links.append('https://stepic.org{}'.format(link))
+
+    return courses['meta']['has_next']
+
+
+def print_certificate_links():
+    has_next = True
+    page = 1
+    links = []
+
+    while(has_next):
+        has_next = get_certificates_by_course(links, page)
+        page += 1
+
+    for link in links:
+        print(link)
+
+
+print_certificate_links()

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -17,26 +17,6 @@ token = resp.json()['access_token']
 # 3. Call API (https://stepic.org/api/docs/) using this token.
 # Example:
 
-def get_certificates(page_number):
-    api_url = 'https://stepic.org/api/certificates?page={}'.format(page_number)
-    certificate = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
-
-    for i in certificate['certificates']:
-        print(i['url'])
-
-    return certificate['meta']['has_next']
-
-# works slow, because data in api/certificates sparsed through pages
-def get_certificate_links():
-    has_next = True
-    page = 1
-
-    while(has_next):
-        has_next = get_certificates(page)
-        page += 1
-
-
-# courses api provides courses without blank pages
 def get_certificates_by_course(links, page_number):
     api_url = 'https://stepic.org/api/courses?page={}'.format(page_number)
     courses = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
@@ -63,3 +43,4 @@ def print_certificate_links():
 
 
 print_certificate_links()
+

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -17,30 +17,30 @@ token = resp.json()['access_token']
 # 3. Call API (https://stepic.org/api/docs/) using this token.
 # Example:
 
-def get_certificates_by_course(links, page_number):
-    api_url = 'https://stepic.org/api/courses?page={}'.format(page_number)
-    courses = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
+def get_user_id():
+    api_url = 'https://stepic.org/api/stepics/1'
+    user = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
+    return user['users'][0]['id']
 
-    for i in courses['courses']:
-        link = i['certificate_link']
-        if link:
-            links.append('https://stepic.org{}'.format(link))
 
-    return courses['meta']['has_next']
+def print_certificates(page_number):
+    id = get_user_id()
+    api_url = 'https://stepic.org/api/certificates?user={}&page={}'.format(id, page_number)
+    certificate = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
+
+    for i in certificate['certificates']:
+        print(i['url'])
+
+    return certificate['meta']['has_next']
 
 
 def print_certificate_links():
     has_next = True
     page = 1
-    links = []
 
     while(has_next):
-        has_next = get_certificates_by_course(links, page)
+        has_next = print_certificates(page)
         page += 1
-
-    for link in links:
-        print(link)
 
 
 print_certificate_links()
-

--- a/examples/get_certificates_urls_example.py
+++ b/examples/get_certificates_urls_example.py
@@ -23,24 +23,51 @@ def get_user_id():
     return user['users'][0]['id']
 
 
-def print_certificates(page_number):
+def get_certificates(page_number):
     id = get_user_id()
     api_url = 'https://stepic.org/api/certificates?user={}&page={}'.format(id, page_number)
     certificate = requests.get(api_url, headers={'Authorization': 'Bearer '+ token}).json()
 
     for i in certificate['certificates']:
-        print(i['url'])
+        links.append(i['url'])
 
     return certificate['meta']['has_next']
 
 
-def print_certificate_links():
+def get_certificate_links():
     has_next = True
     page = 1
 
     while(has_next):
-        has_next = print_certificates(page)
+        has_next = get_certificates(page)
         page += 1
 
 
-print_certificate_links()
+links = []
+get_certificate_links()
+
+
+f = open('certificates.html', 'w', encoding='utf-8')
+
+begin = """<html>
+<head><title> Certificates </title>
+<style>
+   ol {
+    line-height: 1.5;
+   }
+</style>
+</head>
+<body>
+<h1> Certificates </h1>
+<ol>
+"""
+
+end = """</ol>
+</body>
+</html>"""
+
+f.write(begin)
+for url in links:
+    f.write('<li><a href="{}">{}</a></li> \n'.format(url ,url))
+f.write(end)
+f.close()


### PR DESCRIPTION
Pull request  from Yalysheva Natalia due to JetBrains internship task.

Faced the problem that certificates are not grouped in first pages what cases more than 1000 requests to pages with empty field 'certificates'. 

AL: 
![certificates](https://cloud.githubusercontent.com/assets/8366351/15910628/67ac4a1c-2dd4-11e6-8f1d-6d6a9168a282.png)
