### PR TITLE
Top lessons example: Too huge top bug fix

### DIFF
--- a/examples/top_lessons_by_reactions.py
+++ b/examples/top_lessons_by_reactions.py
@@ -65,7 +65,7 @@ for i in range(NUM_OF_REACTION_PAGES):
 sorted_lessons = sorted(course_reactons.items(), key=operator.itemgetter(1), reverse=True)
 
 # Add all equal to the last
-while len(sorted_lessons) != NUM_OF_REACTION_TOP and \
+while len(sorted_lessons) > NUM_OF_REACTION_TOP and \
       sorted_lessons[NUM_OF_REACTION_TOP][1] == sorted_lessons[NUM_OF_REACTION_TOP - 1][1]:
     NUM_OF_REACTION_TOP += 1
 


### PR DESCRIPTION
Bug in #29 fixed: previously it would fail if we had less lessons than `NUM_OF_REACTION_TOP`.